### PR TITLE
Add Metadata Remover to design tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of free, browser-based tools that do one thing well — for devel
 - **[collage.tools](https://collage.tools)** — Grid collages, seamless Instagram carousels, before/after sliders and moodboards with color-palette extraction.
 - **[favicon.tools](https://favicon.tools)** — Generate a full favicon set from an image, emoji or text, convert an existing logo, or audit what a live site serves.
 - **[Arabify](https://arabify.io)** — Arabic calligraphy generator and logo maker with authentic Kufic, Naskh, Diwani and Nastaliq styles.
+- **[Metadata Remover](https://metadataremover.ai/)** — Inspect and remove image metadata locally in the browser, with no upload or sign-up.
 
 ## PDF & files
 


### PR DESCRIPTION
Adds [Metadata Remover](https://metadataremover.ai/) to Design & images.

It is a free browser-based tool that inspects and removes image metadata locally, without upload or sign-up.

I maintain Metadata Remover. The PR follows the one-line contribution format and changes one entry only.