### PR TITLE
Add MetadataRemover.ai EXIF remover to Design & images

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated list of free, browser-based tools that do one thing well — for devel
 - **[tldraw](https://tldraw.com)** — Fast, collaborative infinite canvas for drawing and diagramming.
 - **[Coolors](https://coolors.co)** — Generate, tweak and save color palettes in seconds.
 - **[remove.bg](https://remove.bg)** — Remove the background from any photo automatically.
+- **[MetadataRemover.ai EXIF remover](https://metadataremover.ai/exif-remover)** — Remove supported EXIF and GPS metadata locally in the browser, with no upload or account required.
 - **[collage.tools](https://collage.tools)** — Grid collages, seamless Instagram carousels, before/after sliders and moodboards with color-palette extraction.
 - **[favicon.tools](https://favicon.tools)** — Generate a full favicon set from an image, emoji or text, convert an existing logo, or audit what a live site serves.
 - **[Arabify](https://arabify.io)** — Arabic calligraphy generator and logo maker with authentic Kufic, Naskh, Diwani and Nastaliq styles.


### PR DESCRIPTION
## Summary

- add MetadataRemover.ai EXIF remover to the Design & images section
- describe its free, local browser workflow in one concrete line

Disclosure: I maintain MetadataRemover.ai.